### PR TITLE
Fix: Mask LANGID to 16-bit to resolve broken language auto-detection

### DIFF
--- a/nsis/tesseract.nsi
+++ b/nsis/tesseract.nsi
@@ -1241,6 +1241,7 @@ Function .onInit
   ;done:
     ; Make selection based on System language ID
     System::Call 'kernel32::GetSystemDefaultLangID() i .r0'
+    IntOp $0 $0 & 0xFFFF ; Mask the value to 16 bits to ensure only the LANGID is kept
     ;http://msdn.microsoft.com/en-us/library/dd318693%28v=VS.85%29.aspx
     StrCmp $0 "1078" Afrikaans
     StrCmp $0 "1052" Albanian


### PR DESCRIPTION
## Description
This PR fixes a bug in the NSIS installer where system language auto-detection fails on certain Windows environments.

### The Problem
The current script calls `kernel32::GetSystemDefaultLangID()`. While a `LANGID` is technically a **16-bit** value (short), the NSIS `System::Call` plugin can return it as a **32-bit** integer. 

In many cases, the upper bytes of the register contain "garbage" data (e.g., a return value of `1508361` instead of `1033`). This causes all subsequent `StrCmp` checks to fail because the string comparison expects the exact 4-digit ID, resulting in no language being pre-selected during installation.

### The Solution
I have added a bitwise AND operation (`IntOp $0 $0 & 0xFFFF`) immediately after the system call. This masks the value to 16 bits, discarding any high-byte noise and ensuring that `$0` contains only the valid `LANGID`.

## Changes
- Modified `.onInit` in `tesseract.nsi` to include the bitwise mask.

## Additional Information
- Workaround for: #91
- Source: [NSIS Forums: GetSystemDefaultLangID return value quirk](https://nsis-dev.github.io/NSIS-Forums/html/t-252680.html)